### PR TITLE
Simplify unary minus

### DIFF
--- a/eqn.gemspec
+++ b/eqn.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Zach Schneider']
   spec.email         = ['zach@aha.io']
 
-  spec.summary       = 'A gem to evaluate numerical equations.'
-  spec.description   = 'A gem to evaluate numerical equations. Includes support for variables and functions.'
+  spec.summary       = 'A gem to evaluate mathematical equations.'
+  spec.description   = 'A gem to evaluate mathematical equations. Includes support for variables and functions.'
   spec.homepage      = 'https://github.com/schneidmaster/eqn'
   spec.license       = 'MIT'
 

--- a/lib/eqn.treetop
+++ b/lib/eqn.treetop
@@ -112,7 +112,8 @@ grammar Eqn
   end
 
   rule sign
-    '+' / '-' <Eqn::Terminal::Sign>
+      '+' 
+    / '-' <Eqn::Terminal::UnaryMinus>
   end
 
   rule digits

--- a/lib/eqn/number.rb
+++ b/lib/eqn/number.rb
@@ -20,14 +20,14 @@ module Eqn
     # Node class for a signed number.
     class SignedNumber < EqnNode
       def value(vars = {})
-        # Store sign if any.
-        sign_negative = elements.shift.negative? if elements.first.is_a?(Terminal::Sign)
-
-        # Evaluate float.
-        value = elements.shift.value(vars)
-
-        # Apply sign if any.
-        sign_negative ? -value : value
+        first_element = elements.shift
+        # If first element is unary minus, negate the following value.
+        # Otherwise, simply return the positive value.
+        if first_element.is_a?(Terminal::UnaryMinus)
+          -elements.shift.value(vars)
+        else
+          first_element.value(vars)
+        end
       end
     end
 

--- a/lib/eqn/terminal.rb
+++ b/lib/eqn/terminal.rb
@@ -21,12 +21,8 @@ module Eqn
       end
     end
 
-    # Node class for a number sign.
-    class Sign < EqnNode
-      def negative?
-        text_value == '-'
-      end
-    end
+    # Node class for a unary minus.
+    class UnaryMinus < EqnNode; end
 
     # Node class for an operator.
     class Op < EqnNode

--- a/lib/eqn/version.rb
+++ b/lib/eqn/version.rb
@@ -1,3 +1,3 @@
 module Eqn
-  VERSION = '1.6.3'.freeze
+  VERSION = '1.6.4'.freeze
 end

--- a/spec/eqn/arithmetic_spec.rb
+++ b/spec/eqn/arithmetic_spec.rb
@@ -35,6 +35,13 @@ describe Eqn do
     it_behaves_like 'correctly evaluates', eqn: '-2^-3', expected_result: -0.125
   end
 
+  context 'when evaluating explicitly signed positive integers' do
+    it_behaves_like 'correctly evaluates', eqn: '+1+1', expected_result: 2
+    it_behaves_like 'correctly evaluates', eqn: '+3+-1', expected_result: 2
+    it_behaves_like 'correctly evaluates', eqn: '-3++1', expected_result: -2
+    it_behaves_like 'correctly evaluates', eqn: '-3+-1', expected_result: -4
+  end
+
   context 'when evaluating order of operations' do
     context 'performs multiplication before addition' do
       it_behaves_like 'correctly evaluates', eqn: '1 + 2 * 3', expected_result: 7

--- a/spec/eqn/parse_spec.rb
+++ b/spec/eqn/parse_spec.rb
@@ -3,12 +3,20 @@ describe Eqn do
     it_behaves_like 'correctly evaluates', eqn: '1', expected_result: 1
   end
 
+  context 'when parsing an explicitly signed positive integer' do
+    it_behaves_like 'correctly evaluates', eqn: '+1', expected_result: 1
+  end
+
   context 'when parsing a negative integer' do
     it_behaves_like 'correctly evaluates', eqn: '-1', expected_result: -1
   end
 
   context 'when parsing a positive float' do
     it_behaves_like 'correctly evaluates', eqn: '1.5', expected_result: 1.5
+  end
+
+  context 'when parsing an explicitly signed positive float' do
+    it_behaves_like 'correctly evaluates', eqn: '+1.5', expected_result: 1.5
   end
 
   context 'when parsing a negative float' do


### PR DESCRIPTION
I realized that the grammar is only generating a sign node if it's a unary minus (an extraneous/explicit `+` for a positive number is simply discarded). 