### PR TITLE
Match function names without case insensitivity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,11 +5,12 @@ AllCops:
     - eqn.gemspec
     - Appraisals
     - vendor/**/*
+  NewCops: enable
 
+Layout/LineLength:
+  Max: 130
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context']
-Metrics/LineLength:
-  Max: 130
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/PercentLiteralDelimiters:

--- a/lib/eqn.rb
+++ b/lib/eqn.rb
@@ -7,4 +7,4 @@ Treetop.load(File.join(__dir__, 'eqn.treetop'))
 require File.join(__dir__, 'eqn', 'eqn_node')
 
 # Load other eqn classes.
-Dir.glob File.join(__dir__, 'eqn', '**', '*.rb'), &method(:require)
+Dir.glob(File.join(__dir__, 'eqn', '**', '*.rb')).sort.each(&method(:require))

--- a/lib/eqn.treetop
+++ b/lib/eqn.treetop
@@ -40,19 +40,19 @@ grammar Eqn
   end
 
   rule if_func
-    'if' space? '(' comparation ',' expression ',' expression ')' <Eqn::Function::If>
+    ('if' / 'IF') space? '(' comparation ',' expression ',' expression ')' <Eqn::Function::If>
   end
 
   rule round_func
-    'round' space? '(' expression round_group? ')' <Eqn::Function::Round>
+    ('round' / 'ROUND') space? '(' expression round_group? ')' <Eqn::Function::Round>
   end
 
   rule roundup_func
-    'roundup' space? '(' expression round_group? ')' <Eqn::Function::RoundUp>
+    ('roundup' / 'ROUNDUP') space? '(' expression round_group? ')' <Eqn::Function::RoundUp>
   end
 
   rule rounddown_func
-    'rounddown' space? '(' expression round_group? ')' <Eqn::Function::RoundDown>
+    ('rounddown' / 'ROUNDDOWN') space? '(' expression round_group? ')' <Eqn::Function::RoundDown>
   end
 
   rule round_group

--- a/lib/eqn/calculator.rb
+++ b/lib/eqn/calculator.rb
@@ -27,7 +27,7 @@ module Eqn
     end
 
     def respond_to_missing?(method, _include_private = false)
-      delegated_method?(method) || match_setter?(method) || match_getter?(method)
+      delegated_method?(method) || match_setter?(method) || match_getter?(method) || super
     end
 
     private

--- a/lib/eqn/version.rb
+++ b/lib/eqn/version.rb
@@ -1,3 +1,3 @@
 module Eqn
-  VERSION = '1.6.4'.freeze
+  VERSION = '1.6.5'.freeze
 end

--- a/spec/eqn/function_spec.rb
+++ b/spec/eqn/function_spec.rb
@@ -2,12 +2,14 @@ describe Eqn do
   context 'when evaluating the if function' do
     it_behaves_like 'correctly evaluates', eqn: 'if(5 > 3, 1, 2)', expected_result: 1
     it_behaves_like 'correctly evaluates', eqn: 'if(3 > 5, 1, 2)', expected_result: 2
+    it_behaves_like 'correctly evaluates', eqn: 'IF(5 > 3, 1, 2)', expected_result: 1
   end
 
   context 'when evaluating the round function' do
     it_behaves_like 'correctly evaluates', eqn: 'round(1.75)', expected_result: 2
     it_behaves_like 'correctly evaluates', eqn: 'round(1.5)', expected_result: 2
     it_behaves_like 'correctly evaluates', eqn: 'round(1.25)', expected_result: 1
+    it_behaves_like 'correctly evaluates', eqn: 'ROUND(1.75)', expected_result: 2
   end
 
   context 'when evaluating the round function with decimals' do
@@ -15,12 +17,14 @@ describe Eqn do
     it_behaves_like 'correctly evaluates', eqn: 'round(1.74, 1)', expected_result: 1.7
     it_behaves_like 'correctly evaluates', eqn: 'round(1.7, 1)', expected_result: 1.7
     it_behaves_like 'correctly evaluates', eqn: 'round(1.7, 2)', expected_result: 1.7
+    it_behaves_like 'correctly evaluates', eqn: 'ROUND(1.75, 1)', expected_result: 1.8
   end
 
   context 'when evaluating the roundup function' do
     it_behaves_like 'correctly evaluates', eqn: 'roundup(1.75)', expected_result: 2
     it_behaves_like 'correctly evaluates', eqn: 'roundup(1.5)', expected_result: 2
     it_behaves_like 'correctly evaluates', eqn: 'roundup(1.25)', expected_result: 2
+    it_behaves_like 'correctly evaluates', eqn: 'ROUNDUP(1.75)', expected_result: 2
   end
 
   context 'when evaluating the roundup function with decimals' do


### PR DESCRIPTION
Prior to the introduction of variable support, capitalized function names (`IF(5 > 3, 1, 2)`) were implicitly supported, though never documented. This change adds back support for CAPS function names.